### PR TITLE
Add simple testbench and fix FPU width

### DIFF
--- a/src/datapath/fpu.sv
+++ b/src/datapath/fpu.sv
@@ -10,8 +10,8 @@ module fpu (
     real real_result;
 
     always @(*) begin
-        real_a = $bitstoreal(fp_a);
-        real_b = $bitstoreal(fp_b);
+    real_a = $bitstoreal({32'b0, fp_a});
+    real_b = $bitstoreal({32'b0, fp_b});
 
         case (fp_control)
             2'b00: begin

--- a/tb/arm_tb.sv
+++ b/tb/arm_tb.sv
@@ -1,0 +1,43 @@
+module arm_tb;
+  reg clk = 0;
+  reg reset;
+  wire [31:0] WriteData;
+  wire [31:0] Adr;
+  wire MemWrite;
+
+  // Instantiate top-level design
+  top dut(
+    .clk(clk),
+    .reset(reset),
+    .WriteData(WriteData),
+    .Adr(Adr),
+    .MemWrite(MemWrite)
+  );
+
+  // Clock generation
+  always #5 clk = ~clk;
+
+  // Reset pulse
+  initial begin
+    reset = 1;
+    #22;
+    reset = 0;
+  end
+
+  // Track number of cycles and stop after a timeout
+  integer cycle_count = 0;
+  always @(posedge clk) begin
+    cycle_count <= cycle_count + 1;
+    $display("cycle %0d PC=%h", cycle_count, dut.arm_inst.dp.PC);
+    if (cycle_count > 400) begin
+      $display("Simulation result: R10 = 0x%08h", dut.arm_inst.dp.rf.rf[10]);
+      if (dut.arm_inst.dp.rf.rf[10] == 32'd1) begin
+        $display("Simulation succeeded");
+      end else begin
+        $display("Simulation failed");
+      end
+      dut.arm_inst.dp.rf.dump();
+      $finish;
+    end
+  end
+endmodule


### PR DESCRIPTION
## Summary
- fix `$bitstoreal` calls so Icarus accepts the FPU module
- add a basic SystemVerilog testbench (`tb/arm_tb.sv`) that runs the CPU and prints register R10 after 400 cycles

## Testing
- `iverilog -g2012 -Wall -o arm_tb.vvp tb/arm_tb.sv src/top/top.sv src/arm/arm.sv src/datapath/*.sv src/controller/*.sv`
- `vvp arm_tb.vvp` *(fails: Simulation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68743ec90f68832c9212a5a26fcf5f27