### PR TITLE
Add Mermaid module diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,26 @@
 # arqui OBEJTIVO LOGRAR LOS TEST 
+## Module diagrams
+Los diagramas de cada modulo se encuentran en [docs/module_diagrams](docs/module_diagrams/):
+
+- [adder](docs/module_diagrams/adder.md)
+- [flopr](docs/module_diagrams/flopr.md)
+- [flopenr](docs/module_diagrams/flopenr.md)
+- [mux2](docs/module_diagrams/mux2.md)
+- [mux3](docs/module_diagrams/mux3.md)
+- [mem](docs/module_diagrams/mem.md)
+- [regfile](docs/module_diagrams/regfile.md)
+- [alu](docs/module_diagrams/alu.md)
+- [fpu](docs/module_diagrams/fpu.md)
+- [extend_rotational](docs/module_diagrams/extend_rotational.md)
+- [condcheck](docs/module_diagrams/condcheck.md)
+- [condlogic](docs/module_diagrams/condlogic.md)
+- [mainfsm](docs/module_diagrams/mainfsm.md)
+- [decode](docs/module_diagrams/decode.md)
+- [controller](docs/module_diagrams/controller.md)
+- [datapath](docs/module_diagrams/datapath.md)
+- [arm](docs/module_diagrams/arm.md)
+- [top](docs/module_diagrams/top.md)
+
 
 ### 1. Estructura de alto nivel
 

--- a/docs/module_diagrams/adder.md
+++ b/docs/module_diagrams/adder.md
@@ -1,0 +1,8 @@
+# adder
+
+```mermaid
+flowchart TD
+    a([a]) --> adder_module((adder))
+    b([b]) --> adder_module
+    adder_module --> y([y])
+```

--- a/docs/module_diagrams/alu.md
+++ b/docs/module_diagrams/alu.md
@@ -1,0 +1,11 @@
+# alu
+
+```mermaid
+flowchart TD
+    a([a]) --> alu_module((alu))
+    b([b]) --> alu_module
+    ALUControl([ALUControl]) --> alu_module
+    alu_module --> Result([Result])
+    alu_module --> ALUResult64([ALUResult64])
+    alu_module --> ALUFlags([ALUFlags])
+```

--- a/docs/module_diagrams/arm.md
+++ b/docs/module_diagrams/arm.md
@@ -1,0 +1,15 @@
+# arm
+
+```mermaid
+flowchart TD
+    clk --> arm_module((arm))
+    reset --> arm_module
+    ReadData([ReadData]) --> arm_module
+    arm_module --> controller_sub(controller)
+    arm_module --> datapath_sub(datapath)
+    controller_sub --> datapath_sub
+    datapath_sub --> controller_sub
+    arm_module --> MemWrite
+    arm_module --> Adr
+    arm_module --> WriteData
+```

--- a/docs/module_diagrams/condcheck.md
+++ b/docs/module_diagrams/condcheck.md
@@ -1,0 +1,8 @@
+# condcheck
+
+```mermaid
+flowchart TD
+    Cond([Cond]) --> cc((condcheck))
+    Flags([Flags]) --> cc
+    cc --> CondEx([CondEx])
+```

--- a/docs/module_diagrams/condlogic.md
+++ b/docs/module_diagrams/condlogic.md
@@ -1,0 +1,22 @@
+# condlogic
+
+```mermaid
+flowchart TD
+    subgraph condlogic
+        clk --> cl
+        reset --> cl
+        Cond --> cl
+        ALUFlags --> cl
+        FlagW --> cl
+        PCS --> cl
+        NextPC --> cl
+        RegW --> cl
+        MemW --> cl
+        cl(condlogic)
+        cl --> PCWrite
+        cl --> RegWrite
+        cl --> MemWrite
+    end
+    cl --> condcheck_sub(condcheck)
+    ALUFlags --> flags_regs((flopenr regs))
+```

--- a/docs/module_diagrams/controller.md
+++ b/docs/module_diagrams/controller.md
@@ -1,0 +1,13 @@
+# controller
+
+```mermaid
+flowchart TD
+    Instr([Instr]) --> controller_module((controller))
+    clk --> controller_module
+    reset --> controller_module
+    ALUFlags --> controller_module
+    controller_module --> decode_sub(decode)
+    controller_module --> condlogic_sub(condlogic)
+    decode_sub --> condlogic_sub
+    controller_module --> {PCWrite,MemWrite,RegWrite,IRWrite,AdrSrc,RegSrc,ALUSrcA,ALUSrcB,ResultSrc,ImmSrc,ALUControl,PCS,NextPC,Branch,WAsel,ResultWEn,AandBWrite,RA2Sel,FPUOp}
+```

--- a/docs/module_diagrams/datapath.md
+++ b/docs/module_diagrams/datapath.md
@@ -1,0 +1,41 @@
+# datapath
+
+```mermaid
+flowchart TD
+    subgraph datapath
+        clk --> dp
+        reset --> dp
+        ReadData --> dp
+        PCWrite --> dp
+        NextPC --> dp
+        Branch --> dp
+        RegWrite --> dp
+        IRWrite --> dp
+        AdrSrc --> dp
+        RegSrc --> dp
+        ALUSrcA --> dp
+        ALUSrcB --> dp
+        ResultSrc --> dp
+        ImmSrc --> dp
+        ALUControl --> dp
+        PCS --> dp
+        WAsel --> dp
+        ResultWEn --> dp
+        AandBWrite --> dp
+        RA2Sel --> dp
+        FPUOp --> dp
+        dp(datapath)
+        dp --> Adr
+        dp --> WriteData
+        dp --> Instr
+        dp --> ALUFlags
+    end
+    dp --> flopenr_pc(flopenr)
+    dp --> regfile_sub(regfile)
+    dp --> alu_sub(alu)
+    dp --> fpu_sub(fpu)
+    dp --> extend_sub(extend_rotational)
+    dp --> adder_sub(adder)
+    dp --> mux2_sub(mux2)
+    dp --> mux3_sub(mux3)
+```

--- a/docs/module_diagrams/decode.md
+++ b/docs/module_diagrams/decode.md
@@ -1,0 +1,10 @@
+# decode
+
+```mermaid
+flowchart TD
+    Instr([Instr]) --> decode_module((decode))
+    clk --> decode_module
+    reset --> decode_module
+    decode_module --> mainfsm_sub(mainfsm)
+    decode_module --> {FlagW,PCS,NextPC,RegW,MemW,IRWrite,AdrSrc,ResultSrc,ALUSrcA,ALUSrcB,ImmSrc,RegSrc,ALUControl,Branch,WAsel,ResultWEn,AandBWrite,RA2Sel,FPUOp}
+```

--- a/docs/module_diagrams/extend_rotational.md
+++ b/docs/module_diagrams/extend_rotational.md
@@ -1,0 +1,8 @@
+# extend_rotational
+
+```mermaid
+flowchart TD
+    Instr([Instr]) --> ext_mod((extend_rotational))
+    ImmSrc([ImmSrc]) --> ext_mod
+    ext_mod --> ExtImm([ExtImm])
+```

--- a/docs/module_diagrams/flopenr.md
+++ b/docs/module_diagrams/flopenr.md
@@ -1,0 +1,10 @@
+# flopenr
+
+```mermaid
+flowchart TD
+    clk --> flopenr_module((flopenr))
+    reset --> flopenr_module
+    en --> flopenr_module
+    d([d]) --> flopenr_module
+    flopenr_module --> q([q])
+```

--- a/docs/module_diagrams/flopr.md
+++ b/docs/module_diagrams/flopr.md
@@ -1,0 +1,9 @@
+# flopr
+
+```mermaid
+flowchart TD
+    clk --> flopr_module((flopr))
+    reset --> flopr_module
+    d([d]) --> flopr_module
+    flopr_module --> q([q])
+```

--- a/docs/module_diagrams/fpu.md
+++ b/docs/module_diagrams/fpu.md
@@ -1,0 +1,9 @@
+# fpu
+
+```mermaid
+flowchart TD
+    fp_a([fp_a]) --> fpu_module((fpu))
+    fp_b([fp_b]) --> fpu_module
+    fp_control([fp_control]) --> fpu_module
+    fpu_module --> fp_result([fp_result])
+```

--- a/docs/module_diagrams/mainfsm.md
+++ b/docs/module_diagrams/mainfsm.md
@@ -1,0 +1,14 @@
+# mainfsm
+
+```mermaid
+flowchart TD
+    clk --> fsm((mainfsm))
+    reset --> fsm
+    Op([Op]) --> fsm
+    Funct([Funct]) --> fsm
+    is_mul64 --> fsm
+    is_mul32 --> fsm
+    is_compare_op --> fsm
+    is_fp_op --> fsm
+    fsm --> {IRWrite,AdrSrc,ALUSrcA,ALUSrcB,ResultSrc,NextPC,RegW,MemW,Branch,ALUOp,WAsel,ResultWEn,AandBWrite,RA2Sel,FPUOp}
+```

--- a/docs/module_diagrams/mem.md
+++ b/docs/module_diagrams/mem.md
@@ -1,0 +1,10 @@
+# mem
+
+```mermaid
+flowchart TD
+    clk --> mem_module((mem))
+    we --> mem_module
+    a([a]) --> mem_module
+    wd([wd]) --> mem_module
+    mem_module --> rd([rd])
+```

--- a/docs/module_diagrams/mux2.md
+++ b/docs/module_diagrams/mux2.md
@@ -1,0 +1,9 @@
+# mux2
+
+```mermaid
+flowchart TD
+    d0([d0]) --> mux2_module((mux2))
+    d1([d1]) --> mux2_module
+    s([s]) --> mux2_module
+    mux2_module --> y([y])
+```

--- a/docs/module_diagrams/mux3.md
+++ b/docs/module_diagrams/mux3.md
@@ -1,0 +1,10 @@
+# mux3
+
+```mermaid
+flowchart TD
+    d0([d0]) --> mux3_module((mux3))
+    d1([d1]) --> mux3_module
+    d2([d2]) --> mux3_module
+    s([s[1:0]]) --> mux3_module
+    mux3_module --> y([y])
+```

--- a/docs/module_diagrams/regfile.md
+++ b/docs/module_diagrams/regfile.md
@@ -1,0 +1,14 @@
+# regfile
+
+```mermaid
+flowchart TD
+    clk --> regfile_module((regfile))
+    we3 --> regfile_module
+    ra1([ra1]) --> regfile_module
+    ra2([ra2]) --> regfile_module
+    wa3([wa3]) --> regfile_module
+    wd3([wd3]) --> regfile_module
+    r15([r15]) --> regfile_module
+    regfile_module --> rd1([rd1])
+    regfile_module --> rd2([rd2])
+```

--- a/docs/module_diagrams/top.md
+++ b/docs/module_diagrams/top.md
@@ -1,0 +1,13 @@
+# top
+
+```mermaid
+flowchart TD
+    clk --> top_module((top))
+    reset --> top_module
+    top_module --> arm_sub(arm)
+    top_module --> mem_sub(mem)
+    arm_sub --> mem_sub
+    top_module --> WriteData
+    top_module --> Adr
+    top_module --> MemWrite
+```


### PR DESCRIPTION
## Summary
- create a `docs/module_diagrams` directory with one Markdown file per
  module defined in `desing.sv`
- link the README to the new diagrams using a dedicated section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876f73c1e20832cb51cdc65d6bb327e